### PR TITLE
Fixes validation error when ticking single strand input

### DIFF
--- a/bammmotif/peng/job.py
+++ b/bammmotif/peng/job.py
@@ -114,10 +114,7 @@ def create_job(form, meta_job_form, request):
     output_dir = get_job_output_folder(job_pk)
     job.meme_output = path.join(output_dir, job.meme_output)
     job.json_output = path.join(output_dir, job.json_output)
-    if job.strand == 'on':
-        job.strand = "BOTH"
-    else:
-        job.strand = "PLUS"
+
     if request.user.is_authenticated:
         job.user = request.user
     else:

--- a/bammmotif/peng/models.py
+++ b/bammmotif/peng/models.py
@@ -25,7 +25,7 @@ class PengJob(models.Model):
     zscore_threshold = models.FloatField(default=ShootPengModule.defaults['zscore_threshold'])
     count_threshold = models.IntegerField(default=ShootPengModule.defaults['count_threshold'])
     bg_model_order = models.IntegerField(default=ShootPengModule.defaults['bg_model_order'])
-    strand = models.CharField(max_length=5, default="BOTH")
+    strand = models.CharField(max_length=5, default="BOTH", choices=[('PLUS', 'PLUS'), ('BOTH', 'BOTH')])
     objective_function = models.CharField(
         choices=[(choice, choice) for choice in ShootPengModule.objective_functions],
         max_length=50, default=ShootPengModule.defaults['optimization_score'])

--- a/bammmotif/templates/peng/peng_seeding.html
+++ b/bammmotif/templates/peng/peng_seeding.html
@@ -113,8 +113,8 @@
                         <select id="id_pattern_length" type="number" name="pattern_length" required>
                             <option value="4">4</option>
                             <option value="6">6</option>
-                            <option value="8">8</option>
-                            <option value="10" selected="selected">10</option>
+                            <option value="8" selected>8</option>
+                            <option value="10">10</option>
                         </select>
                     </font></p>
 
@@ -172,12 +172,13 @@
                             <option value="2" selected="selected">2</option>
                         </select>
                     </font></p>
-
+		 <!-- hidden input trick: https://stackoverflow.com/questions/31367098 -->
+		   <input type="hidden" name="strand" value="PLUS" />
                     <p class="indent" style="padding-left: 1.8em"><label for="id_strand"><a class
                         "testpup" onmouseover="nhpup.popup($('#ReverseComplement_Info').html(),{'width':400});"
                         ><span class="glyphicon glyphicon-info-sign" aria-hidden="true"
                                style="color:black"></span></a> Search on Both Strands:</label><font color="#1f2e2e">&nbsp;&nbsp;<input
-                            id="id_strand" name="strand" type="checkbox" checked/></font>
+                            id="id_strand" name="strand" type="checkbox" value="BOTH" checked/></font>
                     </p>
 
                 {% comment %}


### PR DESCRIPTION
Fixed user bug report.

> Hi,
> 
> I’ve been running into an odd issue with the BaMM webserver: when I submit the attached fasta file, it seems to work as expected with default settings. However, when I uncheck the “search on both strands” option under “advanced options”, I get a “Server Error (500)” response. This happened with another fasta file I had lying around as well, so I don’t think it’s specific to this particular file, though I haven’t experimented extensively.
> 
> Best,
> Lars