### PR TITLE
make it possible to update databases without losing the job results

### DIFF
--- a/bammmotif/bamm/models.py
+++ b/bammmotif/bamm/models.py
@@ -1,7 +1,9 @@
 from os import path
 
 from django.db import models
+from django.db.models.signals import post_delete
 from django.conf import settings
+from django.dispatch import receiver
 
 from ..models import JobInfo, MotifDatabase, PengJob
 from ..utils import job_dir_storage as job_fs
@@ -103,6 +105,12 @@ class BaMMJob(models.Model):
 
     def __str__(self):
         return str(self.meta_job.pk)
+
+
+@receiver(post_delete, sender=BaMMJob)
+def delete_job_info(sender, instance, *args, **kwargs):
+    if instance.meta_job:
+        instance.meta_job.delete()
 
 
 class OneStepBaMMJob(models.Model):
@@ -232,3 +240,9 @@ class OneStepBaMMJob(models.Model):
 
     def __str__(self):
         return str(self.meta_job.pk)
+
+
+@receiver(post_delete, sender=OneStepBaMMJob)
+def delete_job_info(sender, instance, *args, **kwargs):
+    if instance.meta_job:
+        instance.meta_job.delete()

--- a/bammmotif/bammscan/models.py
+++ b/bammmotif/bammscan/models.py
@@ -2,6 +2,8 @@ from os import path
 
 from django.conf import settings
 from django.db import models
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
 
 from ..models import JobInfo, MotifDatabase
 
@@ -88,3 +90,8 @@ class BaMMScanJob(models.Model):
     def full_motif_bg_file_path(self):
         return path.join(settings.JOB_DIR, str(self.bgModel_File))
 
+
+@receiver(post_delete, sender=BaMMScanJob)
+def delete_job_info(sender, instance, *args, **kwargs):
+    if instance.meta_job:
+        instance.meta_job.delete()

--- a/bammmotif/mmcompare/models.py
+++ b/bammmotif/mmcompare/models.py
@@ -2,7 +2,9 @@ from os import path
 import re
 
 from django.db import models
+from django.db.models.signals import post_delete
 from django.conf import settings
+from django.dispatch import receiver
 
 from bammmotif.models import JobInfo, MotifDatabase
 
@@ -67,3 +69,9 @@ class MMcompareJob(models.Model):
 
     def __str__(self):
         return str(self.meta_job.job_id)
+
+
+@receiver(post_delete, sender=MMcompareJob)
+def delete_job_info(sender, instance, *args, **kwargs):
+    if instance.meta_job:
+        instance.meta_job.delete()

--- a/bammmotif/peng/models.py
+++ b/bammmotif/peng/models.py
@@ -1,7 +1,9 @@
 from os import path
 
 from django.db import models
+from django.db.models.signals import post_delete
 from django.conf import settings
+from django.dispatch import receiver
 
 from ..models import JobInfo
 from .cmd_modules import ShootPengModule
@@ -80,3 +82,9 @@ class PengJob(models.Model):
     @property
     def input_basename(self):
         return path.basename(self.fasta_file.name)
+
+
+@receiver(post_delete, sender=PengJob)
+def delete_job_info(sender, instance, *args, **kwargs):
+    if instance.meta_job:
+        instance.meta_job.delete()

--- a/run_web.sh
+++ b/run_web.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -e
 # Wait for mysql to start
 echo Waiting $MYSQL_STARTUP_DELAY_SECONDS seconds before webserver startup
 sleep $MYSQL_STARTUP_DELAY_SECONDS


### PR DESCRIPTION
This PR solves following problems related to the motif databases

- updating a database to higher version now does not remove jobs that were using the older version as MMcompare database.
- After deleting a motif database, the associated jobs are not showing in the `find my job` section.

We can now fix bugs and expand the motif databases without losing the user's jobs. :tada:

