### PR TITLE
bamm result page now ranks motifs properly

### DIFF
--- a/bammmotif/models/models.py
+++ b/bammmotif/models/models.py
@@ -225,6 +225,9 @@ class Motifs(models.Model):
     def __str__(self):
         return self.motif_ID
 
+    def rank_score(self):
+        return self.m_aurrc * self.occurrence
+
 
 class DbMatch(models.Model):
     match_ID = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)

--- a/bammmotif/templates/bamm/bamm_result_detail.html
+++ b/bammmotif/templates/bamm/bamm_result_detail.html
@@ -33,7 +33,7 @@
                 {% endif %}
                 <th> Download </th>
             </tr>
-            {% for m in result.meta_job.motifs_set.all|dictsort:"job_rank" %}
+            {% for m in result.meta_job.motifs_set.all|dictsortreversed:"rank_score" %}
                 <tr>
                     <td> <a href="#{{m.job_rank}}" style="color:black">{{m.job_rank}} </a></td>
                     <td> <a href="#{{m.job_rank}}" style="color:black"> {{m.iupac}} </a></td>
@@ -55,7 +55,7 @@
         </table>
     </div>
 
-    {% for m in result.meta_job.motifs_set.all|dictsort:"job_rank" %}
+    {% for m in result.meta_job.motifs_set.all|dictsortreversed:"rank_score" %}
         <a id="{{m.job_rank}}">  </a>
         <div class="jumbotron" style="background-color:white"><font color="black">
 


### PR DESCRIPTION
Now motifs on output page are ranked according to m_aurrc * occurrence and not by the performance of their seeds. :tada: