### PR TITLE
adds configuration option to set tmp dir

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -26,6 +26,7 @@ MEDIA_DIR=/var/webserver/media_db
 LOG_DIR=/var/webserver/logs
 MOTIF_DB_DIR=/var/webserver/motif_db
 BACKUP_DIR=/var/webserver/backups
+TMP_DIR=/tmp
 
 # email logger setttings
 # ######################
@@ -65,6 +66,9 @@ DJANGO_DEBUG=1
 
 # controls the verbosity of the logger, can be one of DEBUG|INFO|WARN|ERROR
 BAMM_LOG_LEVEL=DEBUG
+
+# controls the verbosity of the supervisor process, can be one of error|warn|info|debug|trace|blather
+SUPERVISOR_LOG_LEVEL=info
 
 # the secret key is important for secure communication in production use.
 SECRET_KEY=someverylongrandomstringthatisverynecessaryforhighsecurity

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
 
   celery:
     image: ${SERVER_DOCKER_IMAGE}
-    command: supervisord -c /code/worker.conf
+    command: supervisord -c /code/worker.conf --loglevel ${SUPERVISOR_LOG_LEVEL}
     user: ${BAMM_USER_UID}
     volumes:
       - ${WEBSERVER_DIR}:/code
@@ -28,6 +28,7 @@ services:
       - ${MOTIF_DB_DIR}:/motif_db
       - ${LOG_DIR}:/logs
       - ${BACKUP_DIR}:/backup
+      - ${TMP_DIR}:/tmp_dir
     links:
       - redis_celery
       - db
@@ -81,6 +82,7 @@ services:
       - ${MOTIF_DB_DIR}:/motif_db
       - ${LOG_DIR}:/logs
       - ${BACKUP_DIR}:/backup
+      - ${TMP_DIR}:/tmp_dir
     ports:
       - ${SERVER_HOST_PORT}:10080
     links:

--- a/worker.conf
+++ b/worker.conf
@@ -1,16 +1,16 @@
 [supervisord]
 nodaemon=true
+pidfile = /tmp_dir/supervisord.pid
 logfile = /logs/supervisord.log
 logfile_maxbytes = 50MB
 logfile_backups=10
-loglevel = info
 
 [program:priority_queue]
 command=celery -A webserver.celery:app worker --loglevel=%(ENV_BAMM_LOG_LEVEL)s -Q priority
 stopwaitsecs=9999999
 
 [program:beat]
-command=celery -A webserver.celery:app beat --loglevel=%(ENV_BAMM_LOG_LEVEL)s -s /logs/celerybeat-schedule
+command=celery -A webserver.celery:app beat --loglevel=%(ENV_BAMM_LOG_LEVEL)s -s /logs/celerybeat-schedule --pidfile=/tmp_dir/celerybeat.pid
 stopwaitsecs=9999999
 
 [program:workers]


### PR DESCRIPTION
Make it possible to set the temporary directory for the .pid files. Putting the tmp dir on a ramdisk will remove need to manually clear up .pid files after a computer crash.